### PR TITLE
Replace obsoleted function

### DIFF
--- a/typer-mode.el
+++ b/typer-mode.el
@@ -106,7 +106,7 @@ Any consequential error won’t add punishment-lines. Used by
       (let ((token (pop typer-line-queue)))
 	(goto-char (point-max))
 	(when (not (string= token "\n"))
-	  (goto-char (point-at-bol)))
+	  (goto-char (line-beginning-position)))
 	(typer-do (insert token))
 	(goto-char typer-point))
     (cancel-timer typer-animation-timer)


### PR DESCRIPTION
point-at-bol will be osoleted since Emacs 29.1. Development Emacs generates the following warning.

```
In typer-animate-line-insertion:
typer-mode.el:109:23: Warning: ‘point-at-bol’ is an obsolete function (as of
    29.1); use ‘line-beginning-position’ or ‘pos-bol’ instead.
```